### PR TITLE
Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.1 - 2024-03-19
+
+- Enable logging of the server's stderr channel for easier debugging (though there is a chance this might break the web version).
+- Incorporate latest changes to the `jsonrpc-server` branch.
+  See [openlawlibrary/pygls#418](https://github.com/openlawlibrary/pygls/pull/418) for details.
+
 ## v0.1.0 - 2024-01-05
 
 Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.1.1 - 2024-03-19
 
+- The extension should now automatically restart the server when the source is modified
 - Enable logging of the server's stderr channel for easier debugging (though there is a chance this might break the web version).
 - Incorporate latest changes to the `jsonrpc-server` branch.
   See [openlawlibrary/pygls#418](https://github.com/openlawlibrary/pygls/pull/418) for details.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: wasm
 
-PYTHON_VERSION=3.12.1
+PYTHON_VERSION=3.12.2
 WASI_VERSION=wasi_sdk-20
+
+wasm: wasm/lib.dir.json
 
 wasm/python.wasm:
 	gh release download v$(PYTHON_VERSION) \
@@ -25,5 +27,3 @@ wasm/lib.dir.json: wasm/python.wasm requirements.txt
 		-r requirements.txt
 
 	npx dir-dump wasm/lib/ --out wasm/lib.dir.json
-
-wasm: wasm/lib.dir.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ attrs==23.2.0
     #   lsprotocol
 cattrs==23.2.3
     # via lsprotocol
-lsprotocol==2023.0.0
+lsprotocol==2023.0.1
     # via pygls
 pygls @ git+https://github.com/alcarney/pygls.git@jsonrpc-server

--- a/src/common/client.ts
+++ b/src/common/client.ts
@@ -211,11 +211,17 @@ export class PyglsClient {
         // Restart the server if the user modifies it.
         context.subscriptions.push(
             vscode.workspace.onDidSaveTextDocument(async (document: vscode.TextDocument) => {
-                const expectedUri = vscode.Uri.file(this.getServerPath())
+                if (!vscode.workspace.workspaceFolders) {
+                    return
+                }
+                const documentUri = document.uri.toString()
 
-                if (expectedUri.toString() === document.uri.toString()) {
-                    this.logger.appendLine('server modified, restarting...')
-                    await this.start()
+                for (let workspaceFolder of vscode.workspace.workspaceFolders) {
+                    let serverUri = vscode.Uri.joinPath(workspaceFolder.uri, this.getServerPath())
+                    if (serverUri.toString() === documentUri) {
+                        this.logger.appendLine('server modified, restarting...')
+                        await this.start()
+                    }
                 }
             })
         )

--- a/src/common/client.ts
+++ b/src/common/client.ts
@@ -88,11 +88,11 @@ export class PyglsClient {
         const module = await WebAssembly.compile(bits)
         const process = await wasm.createProcess('pygls-server', module, { initial: 160, maximum: 160, shared: true }, options)
 
-        // Throws errors on the web to do with SharedArrayBuffers and COI...
-        // const decoder = new TextDecoder('utf-8')
-        // process.stderr!.onData((data) => {
-        //     this.stderr.append(decoder.decode(data))
-        // })
+        // Might throw errors on the web to do with SharedArrayBuffers and COI...
+        const decoder = new TextDecoder('utf-8')
+        process.stderr!.onData((data) => {
+            this.stderr.append(decoder.decode(data))
+        })
 
         return process
     }


### PR DESCRIPTION
- The extension should now automatically restart the server when the source is modified
- Enable logging of the server's stderr channel for easier debugging (though there is a chance this might break the web version).
-  Update dependencies and pull in the latest changes to openlawlibrary/pygls#418